### PR TITLE
add connection to Amazon RDS

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,2 +1,7 @@
 DEBUG=False
 SECRET_KEY=SAMPLE_SECRET_KEY
+RDS_HOST=samplerds.host.com
+RDS_NAME=sample_rds_name
+RDS_USER=sample_rds_user
+RDS_PASSWORD=sample_rds_password
+RDS_PORT=sample_rds_port

--- a/server/config/settings/base.py
+++ b/server/config/settings/base.py
@@ -86,10 +86,25 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 
+RDS_HOST = config('RDS_HOST')
+RDS_PORT = config('RDS_PORT')
+RDS_NAME = config('RDS_NAME')
+RDS_USER = config('RDS_USER')
+RDS_PASSWORD = config('RDS_PASSWORD')
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': str(Path(BASE_DIR, 'db.sqlite3')),
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': RDS_HOST,
+        'PORT': RDS_PORT,
+        'NAME': RDS_NAME,
+        'USER': RDS_USER,
+        'PASSWORD': RDS_PASSWORD,
+        # Set MySQL Strict Mode
+        # ref:https://docs.djangoproject.com/en/3.0/ref/databases/#mysql-sql-mode
+        'OPTIONS': {
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        },
     }
 }
 

--- a/server/config/settings/local.py
+++ b/server/config/settings/local.py
@@ -1,1 +1,9 @@
 from .base import *
+
+# Local default : uses db.sqlite3
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': str(Path(BASE_DIR, 'db.sqlite3')),
+    }
+}

--- a/server/requirements/base.txt
+++ b/server/requirements/base.txt
@@ -1,3 +1,4 @@
 Django==3.0.4
 djangorestframework==3.11.0
 python-decouple==3.3
+mysqlclient==1.4.6


### PR DESCRIPTION
- add package `mysqlclient` to requirements
- edit base settings to use RDS database
- edit local settings to use sqlite database
- edit .env.example to include RDS-related variables